### PR TITLE
Allow for more flexible instance group configurations

### DIFF
--- a/batch/library/emr
+++ b/batch/library/emr
@@ -87,8 +87,11 @@ class ElasticMapreduceCluster():
         if steps is not None:
             parameters['steps'] = self.get_boto_step_specs(steps)
 
-        if 'vpc_subnet_id' in arguments:
-            parameters['api_params'] = { 'Instances.Ec2SubnetId': arguments.pop('vpc_subnet_id') }
+        vpc_subnet_id = arguments.pop('vpc_subnet_id', None)
+        if vpc_subnet_id:
+            parameters['api_params'] = {
+                'Instances.Ec2SubnetId': vpc_subnet_id
+            }
 
         parameters.update(arguments)
         return parameters
@@ -212,12 +215,12 @@ def main():
         argument_spec = dict(
             name                 = dict(required=True),
             availability_zone    = dict(),
-            job_flow_role        = dict(),
+            job_flow_role        = dict(default=None),
             instance_groups      = dict(),
             tags                 = dict(),
-            vpc_subnet_id        = dict(),
+            vpc_subnet_id        = dict(default=None),
             visible_to_all_users = dict(),
-            log_uri              = dict(),
+            log_uri              = dict(default=None),
             bootstrap_actions    = dict(),
             steps                = dict(),
             keypair_name         = dict(),

--- a/batch/provision.yml
+++ b/batch/provision.yml
@@ -6,23 +6,35 @@
   vars:
     # The following vars should probably be overridden
     - name: ETL
+    - master_instance_num: 1
+    - master_instance_type: m1.medium
+    - core_instance_num: 1
+    - core_instance_type: m1.medium
     - task_instance_num: 1
     - task_instance_type: m1.medium
     - task_instance_bid: 0.03
-    - master_instance_num: 1
-    - master_instance_type: m1.small
-    - core_instance_num: 2
-    - core_instance_type: m1.small
+    - instance_groups:
+        master:
+          num_instances: "{{ master_instance_num }}"
+          type: "{{ master_instance_type }}"
+          market: ON_DEMAND
+        core:
+          num_instances: "{{ core_instance_num }}"
+          type: "{{ core_instance_type }}"
+          market: ON_DEMAND
+        task:
+          num_instances: "{{ task_instance_num }}"
+          type: "{{ task_instance_type }}"
+          market: SPOT
+          bidprice: "{{ task_instance_bid }}"
     - bootstrap_actions: {}
     - steps: {}
-    # The following vars may be overridden
     - keypair_name: "{{ lookup('env', 'AWS_KEYPAIR_NAME') }}"
     - role: emr
     - ami_version: 2.4.7
-    # The following variables *must* be overridden
-    # - vpc_subnet_id: subnet-7bc4913d
-    # - user_info: []
-    # - log_uri: s3://some-bucket-name
+    - vpc_subnet_id: !!null
+    - user_info: []
+    - log_uri: !!null
   tasks:
     - name: provision EMR cluster
       local_action:
@@ -34,20 +46,7 @@
         visible_to_all_users: yes
         job_flow_role: "{{ role }}"
         ami_version: "{{ ami_version }}"
-        instance_groups:
-          master:
-            num_instances: "{{ master_instance_num }}"
-            type: "{{ master_instance_type }}"
-            market: ON_DEMAND
-          core:
-            num_instances: "{{ core_instance_num }}"
-            type: "{{ core_instance_type }}"
-            market: ON_DEMAND
-          task:
-            num_instances: "{{ task_instance_num }}"
-            type: "{{ task_instance_type }}"
-            market: SPOT
-            bidprice: "{{ task_instance_bid }}"
+        instance_groups: $instance_groups
         bootstrap_actions: $bootstrap_actions
         steps: $steps
       register: jobflow


### PR DESCRIPTION
This enables us to override *all* of the instance groups. This enables us to run clusters with large numbers of core instances acquired from the spot market.

Some of our jobs were failing on m3.xlarge clusters because they were running out of space in HDFS. This is due to the fact that m3.xlarge uses SSDs instead of spinning platter disks and have much less space available per node. For this reason we need more core nodes and less task nodes.

@brianhw