### PR TITLE
add support for service roles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ nosetests.xml
 .pydevproject
 
 .DS_Store
+.idea

--- a/batch/library/emr
+++ b/batch/library/emr
@@ -216,6 +216,7 @@ def main():
             name                 = dict(required=True),
             availability_zone    = dict(),
             job_flow_role        = dict(default=None),
+            service_role         = dict(default='EMR_DefaultRole'),
             instance_groups      = dict(),
             tags                 = dict(),
             vpc_subnet_id        = dict(default=None),

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 ansible==1.4.4	# GPL v3
-boto==2.22.1	# MIT
+boto==2.38.0    # MIT


### PR DESCRIPTION
@brianhw @jab5569 

This change sets a default service role for new EMR clusters. Hopefully this will allow us to continue to provision clusters after the June 30th deadline.