### PR TITLE
Add ability to specify AWS region.

### DIFF
--- a/batch/library/emr
+++ b/batch/library/emr
@@ -5,10 +5,11 @@ import re
 import time
 import traceback
 
+import boto.ec2
+import boto.emr
+
 from boto.exception import EC2ResponseError
-from boto.ec2.connection import EC2Connection
 from boto.emr.bootstrap_action import BootstrapAction
-from boto.emr.connection import EmrConnection
 from boto.emr.instance_group import InstanceGroup
 from boto.emr.step import (
     JarStep, StreamingStep, ScriptRunnerStep, InstallPigStep, PigStep, InstallHiveStep, HiveStep
@@ -34,10 +35,10 @@ TERMINAL_STATES = ['TERMINATED', 'COMPLETED', 'FAILED']
 
 class ElasticMapreduceCluster():
 
-    def __init__(self, name=None):
+    def __init__(self, name=None, region='us-east-1'):
         self.name = name
-        self._emr = EmrConnection()
-        self._ec2 = EC2Connection()
+        self._emr = boto.emr.connect_to_region(region)
+        self._ec2 = boto.ec2.connect_to_region(region)
         self.jobflow = self.find_named_jobflow()
 
     def find_named_jobflow(self):
@@ -214,6 +215,7 @@ def main():
     module = AnsibleModule(
         argument_spec = dict(
             name                 = dict(required=True),
+            region               = dict(default='us-east-1'),
             availability_zone    = dict(),
             job_flow_role        = dict(default=None),
             service_role         = dict(default='EMR_DefaultRole'),
@@ -231,9 +233,10 @@ def main():
     )
     arguments = dict(module.params)
     name = arguments.pop('name')
+    region = arguments.pop('region')
 
     try:
-        cluster = ElasticMapreduceCluster(name)
+        cluster = ElasticMapreduceCluster(name, region)
         desired_state = arguments.pop('state')
         if desired_state == 'present':
             changed = cluster.provision_if_necessary(**arguments)

--- a/batch/provision.yml
+++ b/batch/provision.yml
@@ -29,6 +29,7 @@
           bidprice: "{{ task_instance_bid }}"
     - bootstrap_actions: {}
     - steps: {}
+    - region: 'us-east-1'
     - keypair_name: "{{ lookup('env', 'AWS_KEYPAIR_NAME') }}"
     - role: emr
     - ami_version: 2.4.7
@@ -40,6 +41,7 @@
       local_action:
         module: emr
         name: "{{ name }}"
+        region: "{{ region }}"
         keypair_name: "{{ keypair_name }}"
         vpc_subnet_id: "{{ vpc_subnet_id }}"
         log_uri: "{{ log_uri }}"

--- a/batch/terminate.yml
+++ b/batch/terminate.yml
@@ -10,4 +10,5 @@
       local_action:
         module: emr
         name: "{{ name }}"
+        region: "{{ region }}"
         state: absent


### PR DESCRIPTION
This commit adds ability to provision EMR clusters in regions other than the default `us-east-1` region. The provision and terminate scripts now accept an optional `role` parameter, which defaults to `'eu-east-1'`.

*Partner Information*: not an edX partner - 3rd party-hosted open edX instance
*JIRA Ticket*: https://openedx.atlassian.net/browse/OSPR-675