### PR TITLE
Remove redundant 'mode' argument.

### DIFF
--- a/roles/user/tasks/main.yml
+++ b/roles/user/tasks/main.yml
@@ -127,7 +127,6 @@
     content="{{ '\n'.join(item.authorized_keys) }}"
     dest=/home/{{ item.name }}/.ssh/authorized_keys mode=0640
     owner={{ item.name }}
-    mode=0440
   when: item.authorized_keys is defined and item.get('state', 'present') == 'present'
   with_items: user_info
 


### PR DESCRIPTION
The "copy additional authorized keys" task fails to run because the `mode` parameter is specified twice. This commit removes the second `mode` parameter.

*Partner Information*: not an edX partner - 3rd party-hosted open edX instance
*JIRA Ticket*: https://openedx.atlassian.net/browse/OSPR-676