### PR TITLE
set a default region for terminate

### DIFF
--- a/batch/terminate.yml
+++ b/batch/terminate.yml
@@ -3,6 +3,8 @@
 - name: Terminate a cluster
   hosts: localhost
   gather_facts: False
+  vars:
+    - region: 'us-east-1'
   # The following vars must be overridden
   # name: ETL
   tasks:


### PR DESCRIPTION
It is convenient for us to have a default value here so that the region is not a required parameter to this playbook.

@jab5569 @jrowan