### PR TITLE
Move remote-task into edx-analytics-configuration

### DIFF
--- a/batch/boto.cfg
+++ b/batch/boto.cfg
@@ -1,0 +1,3 @@
+[Boto]
+metadata_service_timeout = 60.0
+metadata_service_num_attempts = 60

--- a/batch/config/devstack.cfg
+++ b/batch/config/devstack.cfg
@@ -1,0 +1,56 @@
+[hive]
+release = apache
+database = default
+warehouse_path = hdfs://localhost:9000/edx-analytics-pipeline/warehouse/
+
+[database-export]
+database = reports
+credentials = /edx/etc/edx-analytics-pipeline/output.json
+
+
+[database-import]
+database = edxapp
+credentials = /edx/etc/edx-analytics-pipeline/input.json
+destination = hdfs://localhost:9000/edx-analytics-pipeline/warehouse/
+
+[map-reduce]
+engine = hadoop
+marker = hdfs://localhost:9000/edx-analytics-pipeline/marker/
+
+[event-logs]
+pattern = .*tracking.log.*
+expand_interval = 2 days
+source = hdfs://localhost:9000/data/
+
+[event-export]
+output_root = hdfs://localhost:9000/edx-analytics-pipeline/event-export/output/
+environment = simple
+config = hdfs://localhost:9000/edx-analytics-pipeline/event_export/config.yaml
+gpg_key_dir = hdfs://localhost:9000/edx-analytics-pipeline/event_export/gpg-keys/
+gpg_master_key = master@key.org
+required_path_text = FakeServerGroup
+
+[manifest]
+threshold = 500
+input_format = org.edx.localhost.input.ManifestTextInputFormat
+lib_jar = hdfs://localhost:9000/edx-analytics-pipeline/packages/edx-analytics-hadoop-util.jar
+path = hdfs://localhost:9000/edx-analytics-pipeline/manifest/
+
+[user-activity]
+output_root = hdfs://localhost:9000/edx-analytics-pipeline/activity/
+
+[enrollments]
+interval_start = 2013-11-01
+
+[enrollment-reports]
+src = hdfs://localhost:9000/data/
+destination = hdfs://localhost:9000/edx-analytics-pipeline/enrollment_reports/output/
+offsets = hdfs://localhost:9000/edx-analytics-pipeline/enrollment_reports/offsets.tsv
+blacklist = hdfs://localhost:9000/edx-analytics-pipeline/enrollment_reports/course_blacklist.tsv
+history = hdfs://localhost:9000/edx-analytics-pipeline/enrollment_reports/enrollment_history.tsv
+
+[geolocation]
+geolocation_data = hdfs://localhost:9000/edx-analytics-pipeline/geo.dat
+
+[calendar]
+interval = 2012-01-01-2020-01-01

--- a/batch/task.yml
+++ b/batch/task.yml
@@ -1,0 +1,140 @@
+---
+
+- name: Configure luigi
+  hosts: "{{ name }}"
+  gather_facts: False
+  sudo: True
+  roles:
+    - role: luigi
+      when: write_luigi_config|bool
+
+- name: Run a task
+  hosts: "{{ name }}"
+  gather_facts: False
+
+  vars:
+    - repo: git@github.com:edx/edx-analytics-pipeline.git
+    - branch: master
+    # - root_data_dir: /var/lib/analytics-tasks
+    # - root_log_dir: /var/log/analytics-tasks
+    - working_dir: "{{ root_data_dir }}/{{ uuid }}"
+    - log_dir: "{{ root_log_dir }}/{{ uuid}}"
+    - working_repo_dir: "{{ working_dir }}/repo"
+    - working_venv_dir: "{{ working_dir }}/venv"
+    - virtualenv_python: "/usr/bin/python2.7"
+    - git_servers:
+        # Analytics repositories are currently hosted on github.
+      - hostname: github.com
+        public_key: 'ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ=='
+    - local_log_dir: build/logs
+    - install_env:
+        # EMR runs a modified version of Debian 6 (squeeze)
+        WHEEL_URL: http://edx-wheelhouse.s3-website-us-east-1.amazonaws.com/Debian/squeeze
+        # EMR ships with python 2.7
+        WHEEL_PYVER: 2.7
+
+    # - override_config: path/to/config.cfg (optionally adds a luigi config override)
+
+    # - secure_config_repo: git@github.com:some/repo.git
+    - secure_config_branch: origin/release
+    - secure_config_repo_dir: "{{ working_dir }}/config"
+    # - secure_config: path/to/config.cfg which can be found in the secure config repo
+
+  tasks:
+    - name: known_hosts file exists
+      command: touch /home/{{ ansible_ssh_user }}/.ssh/known_hosts creates=/home/{{ ansible_ssh_user }}/.ssh/known_hosts
+
+    - name: git server in known_hosts file
+      lineinfile: >
+        dest=/home/{{ ansible_ssh_user }}/.ssh/known_hosts
+        regexp=^{{item.hostname}}
+        line="{{ item.hostname }} {{ item.public_key }}"
+      with_items: git_servers
+
+    - name: root directories created
+      file: path={{ item }} state=directory owner=root group=root
+      sudo: True
+      with_items:
+        - "{{ root_data_dir }}"
+        - "{{ root_log_dir }}"
+
+    - name: working directories created
+      file: path={{ item }} state=directory mode=777 owner={{ ansible_ssh_user }} group={{ ansible_ssh_user }}
+      sudo: True
+      with_items:
+        - "{{ working_dir }}"
+        - "{{ working_repo_dir }}"
+        - "{{ working_venv_dir }}"
+
+    - name: log directory created
+      file: path={{ item }} state=directory mode=777 owner={{ ansible_ssh_user }} group={{ ansible_ssh_user }}
+      sudo: True
+      with_items:
+        - "{{ log_dir }}"
+
+    - name: analytics tasks repository checked out
+      git: repo={{ repo }} dest={{ working_repo_dir }} version=release
+
+    - name: branch fetched
+      command: git fetch --all chdir={{ working_repo_dir }}
+
+    - name: branch checked out
+      command: git checkout {{ branch }} chdir={{ working_repo_dir }}
+
+    - name: ensure system packages are installed
+      command: make system-requirements chdir={{ working_repo_dir }}
+      sudo: True
+
+    - name: bootstrap pip
+      command: apt-get install -q -y python-pip
+      sudo: True
+
+    - name: virtualenv installed
+      pip: name=virtualenv version=1.10.1
+      sudo: True
+
+    - name: virtualenv created
+      command: >
+        virtualenv --python={{ virtualenv_python }} {{ working_venv_dir }}
+
+    - name: update pip
+      command: >
+        {{ working_venv_dir }}/bin/pip install -U pip
+
+    - name: virtualenv initialized
+      shell: >
+        . {{ working_venv_dir }}/bin/activate && make install
+        chdir={{ working_repo_dir }}
+      environment: install_env
+
+    - name: logging configured
+      template: src=templates/logging.cfg.j2 dest={{ working_repo_dir }}/logging.cfg
+
+    - name: configuration override removed
+      file: path={{ working_repo_dir }}/override.cfg state=absent
+
+    - name: secure config repository checked out
+      git: repo={{ secure_config_repo }} dest={{ secure_config_repo_dir }} version=release
+      when: secure_config is defined
+
+    - name: secure config branch fetched
+      command: git fetch --all chdir={{ secure_config_repo_dir }}
+      when: secure_config is defined
+
+    - name: secure config branch checked out
+      command: git checkout {{ secure_config_branch }} chdir={{ secure_config_repo_dir }}
+      when: secure_config is defined
+
+    - name: secure config installed
+      command: cp {{ secure_config_repo_dir }}/{{ secure_config }} {{ working_repo_dir }}/override.cfg
+      when: secure_config is defined
+
+    - name: configuration override installed
+      copy: src={{ override_config }} dest={{ working_repo_dir }}/override.cfg mode=644
+      when: override_config is defined
+
+    - name: boto configured
+      copy: src=boto.cfg dest={{ working_repo_dir }}/.boto mode=644
+
+    - name: show working directory
+      debug: var=working_repo_dir

--- a/batch/templates/logging.cfg.j2
+++ b/batch/templates/logging.cfg.j2
@@ -1,0 +1,49 @@
+#
+# Define logging for use with analytics tasks.
+#
+
+[loggers]
+keys=root,edx_analytics,luigi_interface
+
+[handlers]
+keys=stdoutHandler,localHandler
+
+[formatters]
+keys=standard
+
+[logger_root]
+level=INFO
+handlers=localHandler
+
+[logger_edx_analytics]
+# Errors from edx/analytics get routed to stderr.
+level=DEBUG
+handlers=stdoutHandler,localHandler
+qualname=edx.analytics
+propagate=0
+
+[logger_luigi_interface]
+# Errors from luigi-interface get routed to stdout.
+level=DEBUG
+handlers=stdoutHandler,localHandler
+qualname=luigi-interface
+propagate=0
+
+[handler_stdoutHandler]
+# Define as in luigi/interface.py.
+class=StreamHandler
+level=INFO
+formatter=standard
+args=(sys.stdout,)
+
+[handler_localHandler]
+# Define as in edx-platform/common/lib/logsettings.py (for dev logging, not syslog).
+class=logging.handlers.RotatingFileHandler
+formatter=standard
+args=('{{ log_dir }}/edx_analytics.log', 'w')
+# 'maxBytes': 1024 * 1024 * 2,
+# 'backupCount': 5,
+
+[formatter_standard]
+# Define as in edx-platform/common/lib/logsettings.py (for dev logging, not syslog).
+format=%(asctime)s %(levelname)s %(process)d [%(name)s] %(filename)s:%(lineno)d - %(message)s

--- a/bin/remote-task
+++ b/bin/remote-task
@@ -1,0 +1,311 @@
+#!/usr/bin/env python
+"""Execute tasks on a remote EMR cluster."""
+
+import argparse
+import json
+import os
+import pipes
+from subprocess import Popen, PIPE
+import sys
+import uuid
+
+
+STATIC_FILES_PATH = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+EC2_INVENTORY_PATH = os.path.join(STATIC_FILES_PATH, 'plugins', 'ec2.py')
+
+REMOTE_DATA_DIR = '/var/lib/analytics-tasks'
+REMOTE_LOG_DIR = '/var/log/analytics-tasks'
+
+
+def main():
+    """Parse arguments and run the remote task."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--job-flow-id', help='EMR job flow to run the task', default=None)
+    parser.add_argument('--job-flow-name', help='EMR job flow to run the task', default=None)
+    parser.add_argument('--host', help='host:port to run the task on', default=None)
+    parser.add_argument('--vagrant-path', help='path to the root directory containing a running vagrant container', default=None)
+    parser.add_argument('--branch', help='git branch to checkout before running the task', default='release')
+    parser.add_argument('--repo', help='git repository to clone')
+    parser.add_argument('--remote-name', help='an identifier for this remote task')
+    parser.add_argument('--wait', action='store_true', help='wait for the task to complete')
+    parser.add_argument('--verbose', action='store_true', help='display very verbose output')
+    parser.add_argument('--log-path', help='download luigi output streams after completing the task', default=None)
+    parser.add_argument('--user', help='remote user name to connect as', default=None)
+    parser.add_argument('--private-key', help='a private key file to use to connect to the host', default=None)
+    parser.add_argument('--override-config', help='config file to use to run the job', default=None)
+    parser.add_argument('--secure-config', help='config file in secure config repo to use to run the job', default=None)
+    parser.add_argument('--secure-config-branch', help='git branch to checkout to find the secure config file', default=None)
+    parser.add_argument('--secure-config-repo', help='git repository to clone to find the secure config file', default=os.getenv('ANALYTICS_SECURE_REPO'))
+    parser.add_argument('--shell', help='execute a shell command on the cluster and exit', default=None)
+    parser.add_argument('--sudo-user', help='execute the shell command as this user on the cluster', default='hadoop')
+    parser.add_argument('--workflow-profiler', choices=['pyinstrument'], help='profiler to run on the launch-task process', default=None)
+    parser.add_argument('--wheel-url', help='url of the wheelhouse', default=os.getenv('WHEEL_URL'))
+    parser.add_argument('--retry', action='store_true', help='skip setup of the environment, --remote-name also must be specified and point to a valid environment')
+    arguments, extra_args = parser.parse_known_args()
+    arguments.launch_task_arguments = extra_args
+
+    log('Parsed arguments = {0}'.format(arguments))
+    log('Running commands from path = {0}'.format(STATIC_FILES_PATH))
+    uid = arguments.remote_name or str(uuid.uuid4())
+    log('Remote name = {0}'.format(uid))
+
+    if arguments.vagrant_path:
+        parse_vagrant_ssh_config(arguments)
+
+    if arguments.host:
+        inventory = {}
+    else:
+        inventory = get_ansible_inventory()
+
+    if arguments.shell:
+        return_code = run_remote_shell(inventory, arguments, arguments.shell)
+    else:
+        return_code = run_task_playbook(inventory, arguments, uid)
+
+    log('Exiting with status = {0}'.format(return_code))
+    sys.exit(return_code)
+
+
+def run_task_playbook(inventory, arguments, uid):
+    """
+    Execute the ansible playbook that triggers and monitors the remote task execution.
+
+    Args:
+        arguments (argparse.Namespace): The arguments that were passed in on the command line.
+        uid (str): A unique identifier for this task execution.
+    """
+    if not arguments.retry:
+        extra_vars = convert_args_to_extra_vars(arguments, uid)
+        args = ['batch/task.yml', '-e', extra_vars]
+        prep_result = run_ansible(tuple(args), arguments, executable='ansible-playbook')
+        if prep_result != 0:
+            return prep_result
+
+    data_dir = os.path.join(REMOTE_DATA_DIR, uid)
+    log_dir = os.path.join(REMOTE_LOG_DIR, uid)
+    sudo_user = arguments.sudo_user
+
+    env_vars = {}
+    if arguments.workflow_profiler:
+        env_vars['WORKFLOW_PROFILER'] = arguments.workflow_profiler
+        env_vars['WORKFLOW_PROFILER_PATH'] = log_dir
+
+    env_var_string = ' '.join('{0}={1}'.format(k, v) for k, v in env_vars.iteritems())
+
+    command = 'cd {data_dir}/repo && . /home/{sudo_user}/.bashrc && {env_vars}{bg}{data_dir}/venv/bin/launch-task {task_arguments}{end_bg}'.format(
+        env_vars=env_var_string + ' ' if env_var_string else '',
+        data_dir=data_dir,
+        task_arguments=' '.join(arguments.launch_task_arguments),
+        log_dir=log_dir,
+        bg='nohup ' if not arguments.wait else '',
+        end_bg=' &' if not arguments.wait else '',
+        sudo_user=sudo_user,
+    )
+
+    result = run_remote_shell(inventory, arguments, command)
+    if arguments.wait and arguments.log_path:
+        cluster_name = arguments.job_flow_id or arguments.job_flow_name
+        host_group = 'mr_{0}_master'.format(cluster_name)
+        fetch_arguments = [host_group, '-m', 'fetch']
+        if arguments.user:
+            fetch_arguments.extend(['-u', arguments.user])
+        for filename in ('edx_analytics.log', 'launch-task.trace'):
+            module_arguments = 'src={src} dest={dest} flat=yes'.format(
+                src=os.path.join(log_dir, filename),
+                dest=os.path.join(arguments.log_path, filename)
+            )
+            run_ansible(fetch_arguments + ['-a', module_arguments], arguments.verbose)
+
+    return result
+
+
+def convert_args_to_extra_vars(arguments, uid):
+    """
+    Generate the set of variables that need to be passed in to ansible since they are expected to be set by the
+    playbook.
+
+    Args:
+        arguments (argparse.Namespace): The arguments that were passed in on the command line.
+        uid (str): A unique identifier for this task execution.
+    """
+    if arguments.host:
+        name = 'all'
+    else:
+        name = 'mr_{0}_master'.format(arguments.job_flow_id or arguments.job_flow_name)
+    extra_vars = {
+        'name': name,
+        'branch': arguments.branch,
+        'uuid': uid,
+        'root_data_dir': REMOTE_DATA_DIR,
+        'root_log_dir': REMOTE_LOG_DIR,
+    }
+    if arguments.repo:
+        extra_vars['repo'] = arguments.repo
+    if arguments.override_config:
+        extra_vars['override_config'] = arguments.override_config
+    if arguments.secure_config_repo:
+        extra_vars['secure_config_repo'] = arguments.secure_config_repo
+    if arguments.secure_config_branch:
+        extra_vars['secure_config_branch'] = arguments.secure_config_branch
+    if arguments.secure_config:
+        extra_vars['secure_config'] = arguments.secure_config
+    if arguments.wheel_url:
+        extra_vars['install_env'] = {
+            'WHEEL_URL': arguments.wheel_url,
+            'WHEEL_PYVER': '2.7'
+        }
+    if arguments.vagrant_path:
+        extra_vars['write_luigi_config'] = False
+    return json.dumps(extra_vars)
+
+def parse_vagrant_ssh_config(arguments):
+    log('Connecting to vagrant container in {0}'.format(arguments.vagrant_path))
+    command = 'vagrant ssh-config'
+    log('Running command = {0}'.format(command))
+    with open('/dev/null', 'r+') as devnull:
+        proc = Popen(
+            command,
+            stdin=devnull,
+            stdout=PIPE,
+            cwd=arguments.vagrant_path,
+            shell=True
+        )
+        stdout = proc.communicate()[0]
+
+    if proc.returncode != 0:
+        raise RuntimeError('Unable to determine vagrant connectivity parameters.')
+
+    hostname = '127.0.0.1'
+    port = '2222'
+    for line in stdout.split('\n'):
+        split_line = line.strip().split(' ')
+        if len(split_line) != 2:
+            continue
+
+        key, value = split_line
+        if key == "HostName":
+            hostname = value
+        elif key == "User":
+            arguments.user = value
+        elif key == "Port":
+            port = value
+        elif key == "IdentityFile":
+            arguments.private_key = value
+
+    arguments.host = hostname + ':' + port
+
+def get_ansible_inventory():
+    """
+    Ensure the EC2 inventory cache is cleared before running ansible.
+
+    Otherwise new resources will not be present in the inventory which will cause ansible to fail to connect to them.
+
+    """
+    command = [EC2_INVENTORY_PATH, '--refresh-cache']
+    log('Running command = {0}'.format(command))
+    with open('/dev/null', 'r+') as devnull:
+        proc = Popen(
+            command,
+            stdin=devnull,
+            stdout=PIPE,
+            cwd=STATIC_FILES_PATH
+        )
+        stdout = proc.communicate()[0]
+
+    if proc.returncode != 0:
+        raise RuntimeError('Unable to refresh ansible inventory cache.')
+
+    return json.loads(stdout)
+
+
+def run_ansible(args, arguments, executable='ansible'):
+    """
+    Execute ansible passing in the provided arguments.
+
+    Args:
+        args (iterable): A collection of arguments to pass to ansible on the command line.
+        verbose (bool): Tell ansible to produce verbose output detailing exactly what commands it is executing.
+        executable (str): The executable script to invoke on the command line.  Defaults to "ansible".
+
+    """
+    if arguments.host:
+        inventory_file_path = arguments.host + ','
+    else:
+        inventory_file_path = EC2_INVENTORY_PATH
+    executable_path = os.path.join(sys.prefix, 'bin', executable)
+    command = [executable_path, '-i', inventory_file_path] + list(args)
+    if arguments.user:
+        command.extend(['-u', arguments.user])
+    if arguments.private_key:
+        command.extend(['--private-key', arguments.private_key])
+    if arguments.verbose:
+        command.append('-vvvv')
+
+    env = dict(os.environ)
+    env.update({
+        # Ansible may be pulling down private git repos on the remote machine.  Forward the local agent so that the
+        # remote machine can access any repos this one can. These machines are dynamically created, so we don't know
+        # their host key.  In an ideal world we would store the host key at provisioning time, however, that doesn't
+        # happen, so just trust we have the right machine.
+        'ANSIBLE_SSH_ARGS': '-o ForwardAgent=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no'
+    })
+    log('Running command = {0}'.format(command))
+    with open('/dev/null', 'r+') as devnull:
+        proc = Popen(
+            command,
+            stdin=devnull,
+            env=env,
+            cwd=STATIC_FILES_PATH
+        )
+        proc.wait()
+
+    return proc.returncode
+
+
+def run_remote_shell(inventory, arguments, shell_command):
+    """Run a shell command on a hadoop cluster."""
+    port = None
+    if not arguments.host:
+        ansible_group_name = 'mr_{0}_master'.format(arguments.job_flow_id or arguments.job_flow_name)
+        hostname = inventory[ansible_group_name][0]
+    else:
+        split_host = arguments.host.split(':')
+        hostname = split_host[0]
+        if len(split_host) > 1:
+            port = split_host[1]
+    sudo_user = arguments.sudo_user
+    if sudo_user:
+        shell_command = 'sudo -u {0} /bin/bash -c {1}'.format(sudo_user, pipes.quote(shell_command))
+    command = [
+        'ssh',
+        '-tt',
+        '-o', 'ForwardAgent=yes',
+        '-o', 'StrictHostKeyChecking=no',
+        '-o', 'UserKnownHostsFile=/dev/null',
+        '-o', 'KbdInteractiveAuthentication=no',
+        '-o', 'PasswordAuthentication=no',
+        '-o', 'User=' + arguments.user,
+        '-o', 'ConnectTimeout=10',
+    ]
+    if port:
+        command.extend(['-p', port])
+    if arguments.private_key:
+        command.extend(['-i', arguments.private_key])
+    command.extend([hostname, shell_command])
+    log('Running command = {0}'.format(command))
+    proc = Popen(
+        command,
+        cwd=STATIC_FILES_PATH
+    )
+    proc.wait()
+    return proc.returncode
+
+
+def log(message):
+    """Writes debugging information to stderr."""
+    sys.stderr.write(message)
+    sys.stderr.write('\n')
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/ec2.ini
+++ b/plugins/ec2.ini
@@ -1,7 +1,7 @@
 [ec2]
 regions=us-east-1
 destination_variable=route53_domain_name
-backup_destination_variable=public_dns_name
+backup_destination_variable=private_ip_address
 cache_path=/tmp
 cache_max_age=300
 regions_exclude=

--- a/roles/luigi/defaults/main.yml
+++ b/roles/luigi/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+
+luigi_hadoop_version: apache1
+luigi_hadoop_command: /home/hadoop/bin/hadoop
+luigi_hadoop_streaming_jar: /home/hadoop/.versions/1.0.3/share/hadoop/contrib/streaming/hadoop-streaming.jar

--- a/roles/luigi/tasks/main.yml
+++ b/roles/luigi/tasks/main.yml
@@ -1,0 +1,7 @@
+---
+
+- name: configuration directory created
+  file: path=/etc/luigi state=directory mode=755
+
+- name: configuration file written
+  template: src=client.cfg.j2 dest=/etc/luigi/client.cfg mode=644

--- a/roles/luigi/templates/client.cfg.j2
+++ b/roles/luigi/templates/client.cfg.j2
@@ -1,0 +1,4 @@
+[hadoop]
+version: {{ luigi_hadoop_version }}
+command: {{ luigi_hadoop_command }}
+streaming-jar: {{ luigi_hadoop_streaming_jar }}


### PR DESCRIPTION
This completely separates the pipeline's local and remote execution. The intent is to have edx-analytics-pipeline be a self-contained project that is run on a Hadoop master node.

This repo provides tools for managing that process, including remote execution of the pipeline on clusters that were provisioned using the tools found in here.

So as not to break our existing workflows I propose we commit this stuff here first, migrate over all of our existing workflows to just checkout edx-analytics-configuration and run this version of remote-task. Finally we can remove the remote task script from edx-analytics-pipeline since nothing will be depending on it at that point.

This will be a breaking change for Open edX installations, however. We should probably discuss this.

This is ready for review. Note that I changed the remote-task script somewhat, you can diff it with the old version by running:

```bash
diff bin/remote-task ../edx-analytics-pipeline/edx/analytics/tasks/launchers/remote.py
```