### PR TITLE
Use default job flow role (EMR_EC2_DefaultRole).

### DIFF
--- a/batch/provision.yml
+++ b/batch/provision.yml
@@ -34,7 +34,7 @@
     - ec2_attributes: {}
     - region: 'us-east-1'
     - keypair_name: "{{ lookup('env', 'AWS_KEYPAIR_NAME') }}"
-    - role: emr
+    - role: EMR_EC2_DefaultRole
     - ami_version: 2.4.11
     - release_label: ''
     - vpc_subnet_id: !!null


### PR DESCRIPTION
If the user doesn't explicitly set a job flow role using ansible vars, the default EMR role should be used instead of an arbitrary 'emr' role.

JIRA ticket: https://openedx.atlassian.net/browse/OSPR-1173