### PR TITLE
Set action_on_failure in sample-emr-vars.yml.

### DIFF
--- a/batch/sample-emr-vars.yml
+++ b/batch/sample-emr-vars.yml
@@ -17,6 +17,8 @@ steps:
   - type: script
     name: "Install Sqoop"
     step_args: [ "s3://some-s3-bucket/install-sqoop", "s3://some-s3-bucket" ]
+    # You may want to set this to CANCEL_AND_WAIT while debugging step failures.
+    action_on_failure: TERMINATE_JOB_FLOW
 
 # The following variables *must* be overridden
 vpc_subnet_id: subnet-30346e76


### PR DESCRIPTION
`TERMINATE_JOB_FLOW` is the default behavior. This is mostly for documentation purposes to make it easier to see how/where to set a different action on failure.

JIRA ticket: https://openedx.atlassian.net/browse/OLIVE-25