### PR TITLE
Pass --repo parameter to remote-task.

### DIFF
--- a/automation/run-automated-task.sh
+++ b/automation/run-automated-task.sh
@@ -27,8 +27,10 @@ fi
 . $TASKS_BIN/activate
 make -C analytics-tasks install
 
+TASKS_REPO=${TASKS_REPO:-https://github.com/edx/edx-analytics-pipeline.git}
+
 # Define task on the command line, including the task name and all of its arguments.
 # All arguments provided on the command line are passed through to the remote-task call.
-remote-task --job-flow-name="$CLUSTER_NAME" --branch $TASKS_BRANCH --wait --log-path $WORKSPACE/logs/ --remote-name automation --user $TASK_USER --secure-config-branch $SECURE_BRANCH --secure-config-repo $SECURE_REPO --secure-config $SECURE_CONFIG "$@"
+remote-task --job-flow-name="$CLUSTER_NAME" --repo $TASKS_REPO --branch $TASKS_BRANCH --wait --log-path $WORKSPACE/logs/ --remote-name automation --user $TASK_USER --secure-config-branch $SECURE_BRANCH --secure-config-repo $SECURE_REPO --secure-config $SECURE_CONFIG "$@"
 
 cat $WORKSPACE/logs/* || true


### PR DESCRIPTION
Currently the `run-automated-task.sh` script passes the `--branch` parameter to `remote-task`, but there is no way to pass the `--repo` parameter.

This change lets you set the `--repo` parameter via `TASKS_REPO` environment variable, allowing you to use your own fork of edx-analytics-pipeline.

JIRA ticket: https://openedx.atlassian.net/browse/OLIVE-25