### PR TITLE
fix debian squeeze repo issue

### DIFF
--- a/batch/bootstrap/security.sh
+++ b/batch/bootstrap/security.sh
@@ -65,6 +65,11 @@ debian_patch() {
   sudo mv /tmp/sources.list.bk /etc/apt/sources.list
   sudo apt-get clean
   sudo /etc/init.d/ssh restart
+  sudo mv /etc/apt/sources.list /tmp/sources.list.bk
+  sudo sh -c 'echo "deb http://security.debian.org squeeze/updates main contrib non-free" > /etc/apt/sources.list'
+  mkdir /mnt/tmp/packages/
+  sudo -u hadoop bash -c '. /home/hadoop/.bashrc && hadoop dfs -get s3://edx-analytics-public/packages/* /mnt/tmp/packages/'
+  sudo dpkg -i /mnt/tmp/packages/*.deb
 }
 
 main() {


### PR DESCRIPTION
@e0d @brianhw 

Open source community members have asked me how we fixed this issue, I'd like to share this script with them. Note this is somewhat useless without the actual *.deb files.

Also note that the bucket name was already public information.