### PR TITLE
Change bootstrap actions param type from dict to list.

### DIFF
--- a/batch/library/emr
+++ b/batch/library/emr
@@ -171,12 +171,10 @@ class ElasticMapreduceCluster():
 
     def get_boto_bootstrap_action_specs(self, bootstrap_action_configs):
         bootstrap_action_specs = []
-        for name, spec in bootstrap_action_configs.iteritems():
-            path = spec
-            args = []
-            if isinstance(spec, dict):
-                path = spec.get('path')
-                args = spec.get('args', [])
+        for action_config in bootstrap_action_configs:
+            name = action_config.pop('name')
+            path = action_config.pop('path')
+            args = action_config.pop('args', [])
 
             action = {
                 'Name': name,

--- a/batch/sample-emr-vars.yml
+++ b/batch/sample-emr-vars.yml
@@ -10,7 +10,7 @@ master_instance_num: 1
 master_instance_type: m1.small
 
 bootstrap_actions:
-  ganglia:
+  - name: ganglia
     path: s3://elasticmapreduce/bootstrap-actions/install-ganglia
 steps:
   - type: hive_install


### PR DESCRIPTION
In some cases execution order of bootstrap actions can be significant, so use a list to define bootstrap actions instead of a dictionary.

We are already using using a list for the `steps` parameter.

JIRA ticket: https://openedx.atlassian.net/browse/OLIVE-25