### PR TITLE
Allows ansible 1.4.4 to be run on boxes provisioned with ansible 1.9.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 .PHONY: deps
 
 deps:
-	pip install -q -r requirements.txt
+	pip install --no-cache-dir -q -r requirements.txt
 
 # Run ansible in local mode so that it runs the emr module in the
 # local python which is likely necessary since that is where the


### PR DESCRIPTION
Allows edx-analytics-configuration to use ansible 1.4.4 to provision EMR from boxes
provisioned for use with jenkins analytics using edx/configuration ansible 1.9.3.

**JIRA tickets**: Cleanup for [OLIVE-22](https://openedx.atlassian.net/browse/OLIVE-20), [OC-1512](https://tasks.opencraft.com/browse/OC-1512)

**Discussions**: See [discussion on PR 15](https://github.com/edx-ops/edx-jenkins-job-dsl/pull/15#issuecomment-204265069).

**Dependencies**: None

**Sandbox URL**: 

http://52.20.136.133:8080/ - ping me for login credentials.

**Testing instructions**:

See [edx/configuration PR #2939](https://github.com/edx/configuration/pull/2939) for full test instructions.

Expected result is the EMR instance will provision and terminate successfully (if your configuration is correct).  The analytics task executes `run-automated-tasks.sh`, which runs 

    ansible-playbook --connection local -i 'localhost,' batch/provision.yml 

Without this patch (i.e. if `--no-cache-dir` is omitted), then the above command errors with:

    ERROR: debug is not a legal parameter in an Ansible task or handler

**Reviewers**
- [ ] @jbzdak 
- [ ] @mulby 
- [ ] @e0d  