### PR TITLE
Identify EMR server using master_public_dns_name instead of master_private_ip

### DIFF
--- a/batch/provision.yml
+++ b/batch/provision.yml
@@ -63,10 +63,10 @@
 
     - name: add master to group
       local_action: >
-        add_host hostname={{ jobflow.master_private_ip }} groupname=launched_master ansible_ssh_user=hadoop ansible_connection=ssh
+        add_host hostname={{ jobflow.master_public_dns_name }} groupname=launched_master ansible_ssh_user=hadoop ansible_connection=ssh
 
-    - name: display master IP address
-      debug: msg={{ jobflow.master_private_ip }}
+    - name: display master DNS name
+      debug: msg={{ jobflow.master_public_dns_name }}
 
     - name: display job flow ID
       debug: msg={{ jobflow.jobflow_id }}


### PR DESCRIPTION
Allows access to the EMR master node by servers (e.g. devstacks) that sit outside the AWS VPC.

Without this change, EMR services provisioned by provision.yml are referenced by their AWS internal IP addresses, which are not accessible outside of the VPC.

**JIRA tickets**: Cleanup for [OLIVE-22](https://openedx.atlassian.net/browse/OLIVE-20), [OC-1512](https://tasks.opencraft.com/browse/OC-1512)

**Dependencies**: None

**Sandbox URL**: 

http://52.20.136.133:8080/ - ping me for login credentials.

**Testing instructions**:

See [edx/configuration PR #2939](https://github.com/edx/configuration/pull/2939) for full test instructions.

Expected result is the EMR instance will provision and terminate successfully (if your configuration is correct).

Without this page, the EMR provisioning fails with ssh errors.

**Reviewers**
- [ ] @jbzdak 
- [ ] @mulby 
- [ ] @e0d  