### PR TITLE
Jenkins: Prefer IPv4 switch

### DIFF
--- a/roles/jenkins/defaults/main.yml
+++ b/roles/jenkins/defaults/main.yml
@@ -4,6 +4,8 @@ jenkins_group: "edx"
 jenkins_server_name: "jenkins-ci.analytics.edx.org"
 jenkins_port: 8080
 
+jenkins_prefer_ipv4: true
+
 jenkins_version: "1.559"
 jenkins_deb_url: "http://pkg.jenkins-ci.org/debian/binary/jenkins_{{ jenkins_version }}_all.deb"
 jenkins_deb: "jenkins_{{ jenkins_version }}_all.deb"

--- a/roles/jenkins/templates/etc/default/jenkins.j2
+++ b/roles/jenkins/templates/etc/default/jenkins.j2
@@ -6,8 +6,11 @@ NAME=jenkins
 # location of java
 JAVA=/usr/bin/java
 
+# Prefer IPv4 stack
+PREFER_IPV4="-Djava.net.preferIPv4Stack={{ jenkins_prefer_ipv4 }}"
+
 # arguments to pass to java
-JAVA_ARGS="-Djava.awt.headless=true -Djava.io.tmpdir=/var/tmp -Xmx{{ jenkins_heap_size }}"  # Allow graphs etc. to work even when an X server is present
+JAVA_ARGS="-Djava.awt.headless=true -Djava.io.tmpdir=/var/tmp -Xmx{{ jenkins_heap_size }} $PREFER_IPV4"  # Allow graphs etc. to work even when an X server is present
 
 PIDFILE=/var/run/jenkins/jenkins.pid
 

--- a/roles/jenkins/templates/etc/nginx/sites-available/jenkins.j2
+++ b/roles/jenkins/templates/etc/nginx/sites-available/jenkins.j2
@@ -3,7 +3,11 @@ server {
   server_name {{ jenkins_server_name }};
 
   location / {
+    {% if jenkins_prefer_ipv4 %}
     proxy_pass              http://localhost:{{ jenkins_port }};
+    {% else %}
+    proxy_pass              http://[::1]:{{ jenkins_port }};
+    {% endif %}
 
     {% if jenkins_protocol == 'https' %}
     # Rewrite HTTPS requests from WAN to HTTP requests on LAN


### PR DESCRIPTION
**Description:** By default Jenkins binds on IPv6 address [::]:8080, making nginx redirect to localhost:8080 fail. This PR introduces a boolean switch that forces jenkins to listen on IPv4 address.
**JIRA**: [OSPR-1232](https://openedx.atlassian.net/browse/OSPR-1232)

**Testing instructions:**
1. Create `vars.yml` file somewhere, with at least the follwoing contents:

```
jenkins_server_name: '[jenkins_host_URL]'
jenkins_user: jenkins

analytics_configuration_repo: 'https://github.com/edx/edx-analytics-configuration.git'
analytics_configuration_version: 'master'

analytics_pipeline_repo: 'https://github.com/edx/edx-analytics-pipeline.git'
analytics_pipeline_version: 'master'
```
1. Run `jenkins/scheduler.yml`

    ansible-playbook -vvv --user=ubuntu --extra-vars=@"vars.yml" jenkins/scheduler.yml -i "[jenkins_host_URL],"

2. Verify Jenkins is accessible at http://[jenkins_host_URL]:8080
3. Add `jenkins_prefer_ipv4: true` to `vars.yaml and repeat steps 1 and 2.
4. Change `jenkins_prefer_ipv4` to `false` and repeat steps 1 and 2.