### PR TITLE
Misc updates found during execution of new deployment

### DIFF
--- a/automation/run-automated-task.sh
+++ b/automation/run-automated-task.sh
@@ -31,7 +31,7 @@ if [ "$TERMINATE" = "true" ]; then
 fi
 
 . $TASKS_BIN/activate
-make -C analytics-tasks install
+make -C analytics-tasks bootstrap
 
 TASKS_REPO=${TASKS_REPO:-https://github.com/edx/edx-analytics-pipeline.git}
 

--- a/batch/library/emr
+++ b/batch/library/emr
@@ -23,8 +23,7 @@ ALIVE_STATES = ['STARTING', 'BOOTSTRAPPING', 'RUNNING', 'WAITING', 'TERMINATING'
 TERMINAL_STATES = ['TERMINATED', 'TERMINATED_WITH_ERRORS']
 
 # Define values that get configured separately but get mapped to the Instance substructure.
-INSTANCE_PARAMS = {
-    'hadoop_version': 'HadoopVersion',
+SECURITY_GROUPS = {
     'emr_managed_master_security_group': 'EmrManagedMasterSecurityGroup',
     'emr_managed_slave_security_group': 'EmrManagedSlaveSecurityGroup',
     'additional_master_security_groups': 'AdditionalMasterSecurityGroups',
@@ -141,12 +140,16 @@ class ElasticMapreduceCluster():
         elif availability_zone:
             instance_specs['Placement'] = {'AvailabilityZone': availability_zone}
 
-        for arg_name, key_name in INSTANCE_PARAMS.iteritems():
+        hadoop_version = arguments.pop('hadoop_version', None)
+        if hadoop_version:
+            instance_specs['HadoopVersion'] = hadoop_version
+
+        for arg_name, key_name in SECURITY_GROUPS.iteritems():
             arg_value = arguments.pop(arg_name, None)
             if arg_value is not None:
-                instance_specs[key_name] = hadoop_version
+                instance_specs[key_name] = arg_value
 
-        return instance_specs;
+        return instance_specs
 
     def get_boto_instance_group_specs(self, instance_group_configs):
         instance_group_specs = []

--- a/batch/provision.yml
+++ b/batch/provision.yml
@@ -40,6 +40,7 @@
     - vpc_subnet_id: !!null
     - user_info: []
     - log_uri: !!null
+    - additional_master_security_groups: []
   tasks:
     - name: provision EMR cluster
       local_action:
@@ -59,6 +60,7 @@
         applications: $applications
         configurations: $configurations
         ec2_attributes: $ec2_attributes
+        additional_master_security_groups: $additional_master_security_groups
       register: jobflow
 
     - name: add master to group

--- a/plugins/ec2.py
+++ b/plugins/ec2.py
@@ -194,7 +194,9 @@ class Ec2Inventory(object):
 
         # Regions
         self.regions = []
-        configRegions = config.get('ec2', 'regions')
+        configRegions = os.getenv('AWS_REGION')
+        if configRegions is None:
+            configRegions = config.get('ec2', 'regions')
         configRegions_exclude = config.get('ec2', 'regions_exclude')
         if (configRegions == 'all'):
             if self.eucalyptus_host:


### PR DESCRIPTION
Provides the following features:

1. Allow AWS region used by the dynamic inventory script (ec2.py) to be configured via an environment variable instead of the hardcoded value in ec2.ini
2. When using edx-analytics-pipeline to just run remote-task in run-automated-task.sh, use "make bootstrap" instead of "make install". This is *much* faster and only installs the minimum dependency set needed to run remote-task.
3. Support additional master security groups. We are taking the approach of using the default security groups for master nodes and creating a new one that allows SSH from jenkins. This feature had to be fixed to enable assigning additional security groups for master nodes.

Reviewers:
- [x] @brianhw
- [ ] @HassanJaveed84 

FYI: @mtyaka @pomegranited

Related PRs:
* https://github.com/edx/edx-analytics-pipeline/pull/237 - this contains a similar fix for ec2.py that allows AWS region customization.

TODO:
- [x] Deploy a legacy 2.4.11 cluster to make sure this change doesn't break anything