### PR TITLE
fix existing venv issue

### DIFF
--- a/automation/run-automated-task.sh
+++ b/automation/run-automated-task.sh
@@ -7,8 +7,14 @@ mkdir -p $VENV_ROOT
 
 rm -rf $WORKSPACE/logs
 
-virtualenv $VENV_ROOT/analytics-tasks
-virtualenv $VENV_ROOT/analytics-configuration
+if [ ! -d "$VENV_ROOT/analytics-tasks" ]
+then
+    virtualenv $VENV_ROOT/analytics-tasks
+fi
+if [ ! -d "$VENV_ROOT/analytics-configuration" ]
+then
+    virtualenv $VENV_ROOT/analytics-configuration
+fi
 
 TASKS_BIN=$VENV_ROOT/analytics-tasks/bin
 CONF_BIN=$VENV_ROOT/analytics-configuration/bin


### PR DESCRIPTION
Running virtualenv on an existing venv can cause some very weird issues. Specifically we've seen it overwrite existing installations of pip with whatever default it wants to use. This is problematic since we are upgrading pip to 7.1.2 and some older versions of virtualenv want to install 1.5.6. This causes conflicting pip installations to be installed alongside one another.

Reviewers:

- [x] @brianhw 
- [ ] @mtyaka 

