### PR TITLE
Allows --override-config to be used in place of --secure-*

### DIFF
--- a/automation/run-automated-task.sh
+++ b/automation/run-automated-task.sh
@@ -38,6 +38,6 @@ VIRTUALENV_EXTRA_ARGS="${VIRTUALENV_EXTRA_ARGS:-}"
 
 # Define task on the command line, including the task name and all of its arguments.
 # All arguments provided on the command line are passed through to the remote-task call.
-remote-task --job-flow-name="$CLUSTER_NAME" --repo $TASKS_REPO --branch $TASKS_BRANCH --wait --log-path $WORKSPACE/logs/ --remote-name automation --user $TASK_USER --virtualenv-extra-args="$VIRTUALENV_EXTRA_ARGS" --secure-config-branch $SECURE_BRANCH --secure-config-repo $SECURE_REPO --secure-config $SECURE_CONFIG "$@"
+remote-task --job-flow-name="$CLUSTER_NAME" --repo $TASKS_REPO --branch $TASKS_BRANCH --wait --log-path $WORKSPACE/logs/ --remote-name automation --user $TASK_USER --virtualenv-extra-args="$VIRTUALENV_EXTRA_ARGS" --secure-config-branch="$SECURE_BRANCH" --secure-config-repo="$SECURE_REPO" --secure-config="$SECURE_CONFIG" --override-config="$OVERRIDE_CONFIG" "$@"
 
 cat $WORKSPACE/logs/* || true


### PR DESCRIPTION
Some analytics pipelines use an override config file instead of secure config file in a secure repo.
This change modifies `run-automated-tasks.sh`'s `remote-task` call to allow the `--secure-*` arguments to be empty, and adds the optional `--override-config` argument.

Prior to this change, `run-automated-tasks.sh`'s `remote-task` call would error if there was no `SECURE_REPO`, `SECURE_BRANCH` and `SECURE_CONFIG` set, and not respond to any `OVERRIDE_CONFIG` env var.

**JIRA tickets**: [OC-1561](https://tasks.opencraft.com/browse/OC-1561)

**Testing instructions**:

1. Run `automation/run-automated-tasks.sh` on a configured analytics pipeline server, using these combinations of arguments:
    * Unset `SECURE_REPO`, `SECURE_BRANCH`, `SECURE_CONFIG`, `OVERRIDE_CONFIG`
    * Unset `SECURE_REPO`, `SECURE_BRANCH`, `SECURE_CONFIG`, but set `OVERRIDE_CONFIG`
    * Set `SECURE_REPO`, `SECURE_BRANCH`, `SECURE_CONFIG`, `OVERRIDE_CONFIG`
    * Set `SECURE_REPO`, `SECURE_BRANCH`, `SECURE_CONFIG`, but unset `OVERRIDE_CONFIG`
1. Verify that the invoked analytics-pipeline `remote-task` displays the appropriate Parsed Arguments.

**Reviewers**
- [x] @e-kolpakov
- [ ] edX reviewer[s] TBD