### PR TITLE
Set the right SSH username to use when collecting metrics.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ terminate.emr: deps
 
 # We actually connect to the master node, hence the lack of a local connection.
 collect.metrics: deps inventory.refresh
-	ansible-playbook batch/collect.yml -e "$$EXTRA_VARS"
+	ansible-playbook -u "$$TASK_USER" batch/collect.yml -e "$$EXTRA_VARS"
 
 inventory.refresh:
 	./plugins/ec2.py --refresh-cache 2>/dev/null >/dev/null


### PR DESCRIPTION
We just need to specify which SSH username Ansible should be using to connect to the EMR master node when collecting metrics.