### PR TITLE
Add some debugging to metrics collection, which is still tumultuous.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ terminate.emr: deps
 
 # We actually connect to the master node, hence the lack of a local connection.
 collect.metrics: deps inventory.refresh
-	ansible-playbook -u "$$TASK_USER" batch/collect.yml -e "$$EXTRA_VARS"
+	ansible-playbook -vvvv -u "$$TASK_USER" batch/collect.yml -e "$$EXTRA_VARS" || true
 
 inventory.refresh:
 	./plugins/ec2.py --refresh-cache 2>/dev/null >/dev/null

--- a/batch/collect.yml
+++ b/batch/collect.yml
@@ -10,3 +10,7 @@
   tasks:
     - name: run script
       command: "{{ analytics_root }}/venv/bin/python {{ analytics_scripts }}/collect-hadoop-metrics.py {{ analytics_config }}/collect-hadoop-metrics.yaml"
+      register: collection
+    - name: print script output
+      debug:
+        msg: "{{ collection.stdout_lines }}"


### PR DESCRIPTION
As we're still seeing some weird SSH issues when connecting to the master node, we're now using `-vvvv` so we can get the full SSH output as we try to debug these problems.

We're also invoking the playbook by appending `|| true`, so that these SSH failures don't cause Jenkins to think the job failed.  This is important because some tasks downstream will not run if their upstream
requirement "failed" because of an SSH error when collecting the metrics.

We're also spitting out the stdout from the collection script to console so that we have a better idea of what the script is doing, just in case that's part of the "SSH error."