### PR TITLE
Read the workflow logs before collecting metrics.

### DIFF
--- a/automation/run-automated-task.sh
+++ b/automation/run-automated-task.sh
@@ -40,7 +40,7 @@ VIRTUALENV_EXTRA_ARGS="${VIRTUALENV_EXTRA_ARGS:-}"
 # All arguments provided on the command line are passed through to the remote-task call.
 remote-task --job-flow-name="$CLUSTER_NAME" --repo $TASKS_REPO --branch $TASKS_BRANCH --wait --log-path $WORKSPACE/logs/ --remote-name automation --user $TASK_USER --virtualenv-extra-args="$VIRTUALENV_EXTRA_ARGS" --secure-config-branch="$SECURE_BRANCH" --secure-config-repo="$SECURE_REPO" --secure-config="$SECURE_CONFIG" --override-config="$OVERRIDE_CONFIG" "$@"
 
+cat $WORKSPACE/logs/* || true
+
 . $CONF_BIN/activate
 make -C analytics-configuration collect.metrics
-
-cat $WORKSPACE/logs/* || true


### PR DESCRIPTION
Some of the workflow jobs generate a lot of log output, and when we're trying to see if metrics were collected, etc, that stuff is buried somewhere in the middle of the "console output" for the job.

We're just moving the metrics collection to the very end so that it's easier to find no matter how large the workflow's log output is.