### PR TITLE
Shorten the control path.

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -6,3 +6,6 @@
 host_key_checking = False
 roles_path = ./roles
 hostfile = ./plugins/ec2.py
+
+[ssh_connection]
+control_path = %(directory)s/%%h-%%r


### PR DESCRIPTION
Moving this into the ansible.cfg of the configuration repo, which seems to be the preferred configuration based on the priority order that Ansible searches with.