### PR TITLE
Adds EbsConfiguration stanza to InstanceGroup specification

### DIFF
--- a/batch/library/emr
+++ b/batch/library/emr
@@ -168,6 +168,28 @@ class ElasticMapreduceCluster():
                         # Make sure the float is converted to a string.
                         instance_group['BidPrice'] = str(args['bidprice'])
 
+                # Configure the EBS volume
+                if 'volume_size' in args or 'volume_type' in args:
+                    # In GB - beware of EBS minimum sizes for different volume types.
+                    volume_size = int(args.get('volume_size', 32))
+
+                    # st1, gp2, io1, or standard
+                    volume_type = args.get('volume_type', 'gp2')
+
+                    instance_group['EbsConfiguration'] = {
+                        'EbsBlockDeviceConfigs': [
+                            {
+                               'VolumeSpecification': {
+                                   'VolumeType': volume_type,
+                                   'SizeInGB': volume_size,
+                                   # 'Iops': number,  # IO operations per second
+                                },
+                                # 'VolumesPerInstance': 1,
+                           },
+                        ],
+                        'EbsOptimized': True,
+                    }
+
                 instance_group_specs.append(instance_group)
 
         return instance_group_specs

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 ansible==1.4.4	# GPL v3
 boto==2.38.0    # MIT -- used for ec2 inventory
-boto3==1.1.0    # MIT -- used for emr deployment
+boto3==1.4.4    # MIT -- used for emr deployment


### PR DESCRIPTION
This change the EBS volume size to be configured using a new `volume_size` configuration parameter.

Example `instance_groups` configuration which sets `volume_size` on the `core` instance:
```yaml
instance_groups:
  master:
    num_instances: 1
    type: m4.medium
    market: ON_DEMAND
  core:
    num_instances: 1
    type: m4.large
    market: ON_DEMAND
    volume_size: 64
  task:
    num_instances: 2
    type: m4.large
    market: ON_DEMAND
```

**Author notes and concerns**:

1. The current version of boto3 (1.1.0) does not support this option. The latest version (1.4.4) does.
1. I'm unsure how to provide test instructions.  Our client deployed their cluster using this change, and this made the volume size increase as specified.
1. Do you need an additional OpenCraft reviewer here?  Or any further testing done?

**Reviewers**
- [x] @edx/analytics 
