### PR TITLE
Change Ansible to merge in extra vars rather than replace.

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -6,6 +6,7 @@
 host_key_checking = False
 roles_path = ./roles
 hostfile = ./plugins/ec2.py
+hash_behaviour = merge
 
 [ssh_connection]
 control_path = %(directory)s/%%h-%%r

--- a/batch/library/emr
+++ b/batch/library/emr
@@ -500,7 +500,7 @@ def main():
             job_flow_role        = dict(default=None),
             service_role         = dict(default='EMR_DefaultRole'),
             # Instance-level parameters:
-            instance_fleets      = dict(),
+            instance_fleets      = dict(default=None),
             instance_groups      = dict(),
             keypair_name         = dict(),
             availability_zone    = dict(),

--- a/batch/provision.yml
+++ b/batch/provision.yml
@@ -13,6 +13,7 @@
     - task_instance_num: 1
     - task_instance_type: m1.medium
     - task_instance_bid: 0.03
+    - instance_fleets: !!null
     - instance_groups:
         master:
           num_instances: "{{ master_instance_num }}"
@@ -56,6 +57,7 @@
         ami_version: "{{ ami_version }}"
         release_label: "{{ release_label }}"
         instance_groups: $instance_groups
+        instance_fleets: $instance_fleets
         bootstrap_actions: $bootstrap_actions
         steps: $steps
         applications: $applications


### PR DESCRIPTION
Since we define our var overrides via extra vars with a dictionary,
Ansible's default behaviour is to wholesale swap the dictionaries,
seemingly.  This causes an issue when you try to use one or the other of
groups vs fleets.  Due to the logic we have to figure out if the user is
requesting an instance group-backed vs instance fleet-backed cluster, we
would potentially launch with a default group-based setup (ignoring the
fleet config) or with an erroneous string for the fleet config.
Basically, it's broken either way since we can't run 99% of our jobs on
an m1.medium.  From a technical standpoint, though, the cluster could
successfully launch and schedule Hadoop jobs.  They would just
inevitably fail from OOM at some point.

This change properly brings instance_fleets back into the fold by
passing it in, but changes the hash behaviour so that
instance_groups/instance_fleets are always both defined, as they should
be, with the correct defaults to properly trigger the detection logic.