### PR TITLE
Allow instance group/instance fleet configuration to peacefully coexist.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ terminate.emr: deps
 
 # We actually connect to the master node, hence the lack of a local connection.
 collect.metrics: deps inventory.refresh
-	ansible-playbook -vvvv -u "$$TASK_USER" batch/collect.yml -e "$$EXTRA_VARS" || true
+	ansible-playbook -u "$$TASK_USER" batch/collect.yml -e "$$EXTRA_VARS" || true
 
 inventory.refresh:
 	./plugins/ec2.py --refresh-cache 2>/dev/null >/dev/null

--- a/batch/library/emr
+++ b/batch/library/emr
@@ -67,10 +67,10 @@ class ElasticMapreduceCluster():
 
         parameters['Instances'] = self.get_boto_instance_specs(arguments)
 
-        instance_fleets = arguments.pop('instance_fleets', None)
+        instance_fleets = arguments.pop('instance_fleets', {})
         instance_groups = arguments.pop('instance_groups', DEFAULT_INSTANCE_GROUPS)
 
-        if instance_fleets is None:
+        if not instance_fleets:
             self.is_instance_fleet = False
             parameters['Instances']['InstanceGroups'] = self.get_boto_instance_group_specs(instance_groups)
         else:

--- a/batch/provision.yml
+++ b/batch/provision.yml
@@ -13,7 +13,7 @@
     - task_instance_num: 1
     - task_instance_type: m1.medium
     - task_instance_bid: 0.03
-    - instance_fleets: !!null
+    - instance_fleets: {}
     - instance_groups:
         master:
           num_instances: "{{ master_instance_num }}"


### PR DESCRIPTION
Due to how we use/used Ansible, the first iteration of instance fleet
support was being hampered by the default behaviours of Ansible, and by
some of the esoteric syntax we were using.

We slightly changed our logic for detecting fleet vs group, which allows
us to use a more crude-but-effective default value for this work.