### PR TITLE
Upgrade pip and setuptools.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@
 .PHONY: deps
 
 deps:
-	pip install -U pip==7.1.2
+	pip install -U pip==9.0.1
+	pip install -U setuptools==36.6
 	pip install --no-cache-dir -q -r requirements.txt
 
 # Run ansible in local mode so that it runs the emr module in the


### PR DESCRIPTION
Jenkins is running with ancient versions of pip and setuptools in its mkvirtualenv.  This upgrades the versions of each that jobs are run with. 