### PR TITLE
Shorten ssh control path

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -9,4 +9,4 @@ hostfile = ./plugins/ec2.py
 hash_behaviour = merge
 
 [ssh_connection]
-control_path = %(directory)s/%%h-%%r
+control_path = %(directory)s/%%C


### PR DESCRIPTION
This PR fixes issue with update-users jenkins job on new jenkins server which failed due to long ssh control path. I have tested user-activity-edge workflow using this branch which finished successfully.