### PR TITLE
Do not fail pipeline jobs if make `collect.metrics` fails

### DIFF
--- a/automation/run-automated-task.sh
+++ b/automation/run-automated-task.sh
@@ -42,5 +42,7 @@ remote-task --job-flow-name="$CLUSTER_NAME" --repo $TASKS_REPO --branch $TASKS_B
 
 cat $WORKSPACE/logs/* || true
 
+# Attempt to collect hadoop metrics and send them to grafana.  DO NOT fail this
+# script/job if only this step fails.
 . $CONF_BIN/activate
-make -C analytics-configuration collect.metrics
+make -C analytics-configuration collect.metrics || true


### PR DESCRIPTION
Identified as a pain point by the Excessive Alarm Reduction (EAR) working group: https://openedx.atlassian.net/wiki/spaces/DE/pages/996803190/Excessive+Alarm+reduction+working+group