### PR TITLE
Add retry attempts to github pub key downloads.

### DIFF
--- a/roles/user/tasks/main.yml
+++ b/roles/user/tasks/main.yml
@@ -128,6 +128,10 @@
     force=yes
     dest=/home/{{ item.name }}/.ssh/authorized_keys mode=0640
     owner={{ item.name }}
+  register: result
+  until: result is succeeded
+  retries: 5
+  delay: 2
   when: item.github is defined
   with_items:
     - "{{ user_info }}"


### PR DESCRIPTION
You might *think* these retries are un-needed - and so did I until failures actually happened twice this week - such as this one (shown below):
http://jenkins.analytics.edx.org/job/load-google-analytics-permissions/295/console

```
09:53:54 failed: [10.5.0.194] (item={u'github': True, u'type': u'admin', u'name': u'doctoryes'}) => {"changed": false, "dest": "/home/doctoryes/.ssh/authorized_keys", "item": {"github": true, "name": "doctoryes", "type": "admin"}, "msg": "Request failed", "response": "HTTP Error 500: Internal Server Error", "state": "absent", "status_code": 500, "url": "https://github.com/doctoryes.keys"}
```
