### PR TITLE
chore: Increase provision retries from 3 to 6.

### DIFF
--- a/batch/provision.yml
+++ b/batch/provision.yml
@@ -68,7 +68,7 @@
         additional_slave_security_groups: "{{ additional_slave_security_groups }}"
         ebs_root_volume_size: "{{ ebs_root_volume_size }}"
       register: jobflow
-      retries: 3
+      retries: 6
       delay: 5  # Seconds of delay between retries.
       until: jobflow is success  # Stop condition for retries.
 


### PR DESCRIPTION
Stopgap to retry more, in response to  increase in "instance fleet time out" errors on EMR.